### PR TITLE
Define error::success so that error_codes exhibit proper 'truthiness'

### DIFF
--- a/include/nudb/error.hpp
+++ b/include/nudb/error.hpp
@@ -81,6 +81,12 @@ namespace errc = boost::system::errc;
 /// Database error codes.
 enum class error
 {
+    /** Operation succeeded
+
+        Default error_code value.
+     */
+    success = 0,
+
     /** The specified key was not found.
 
         Returned when @ref basic_store::fetch does not


### PR DESCRIPTION
Right now if ec is assigned to key_not_found and then tested in a
conditional, the error code will not evaluate properly. This is
because key_not_found currently is set to 0 (first enum value).

Includes a 'success' error code similar to that defined in
boost::system:

https://www.boost.org/doc/libs/1_61_0/boost/system/error_code.hpp