### PR TITLE
Add version of create() with uid parameter.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.11)
 set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/scripts ${CMAKE_MODULE_PATH})
-project (NuDB VERSION 2.0.2)
+project (NuDB VERSION 2.0.3)
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/doc/quickref.xml
+++ b/doc/quickref.xml
@@ -47,6 +47,8 @@
             <member><link linkend="nudb.ref.nudb__create">create</link></member>
             <member><link linkend="nudb.ref.nudb__erase_file">erase_file</link></member>
             <member><link linkend="nudb.ref.nudb__make_error_code">make_error_code</link></member>
+            <member><link linkend="nudb.ref.nudb__make_salt">make_salt</link></member>
+            <member><link linkend="nudb.ref.nudb__make_uid">make_uid</link></member>
             <member><link linkend="nudb.ref.nudb__recover">recover</link></member>
             <member><link linkend="nudb.ref.nudb__rekey">rekey</link></member>
             <member><link linkend="nudb.ref.nudb__verify">verify</link></member>

--- a/include/nudb/create.hpp
+++ b/include/nudb/create.hpp
@@ -19,6 +19,17 @@
 
 namespace nudb {
 
+/** Return a random uid.
+
+    This function will use the system provided random
+    number device to generate a uniformly distributed
+    64-bit unsigned value suitable for use the uid
+    value in a call to @ref create.
+*/
+template<class = void>
+std::uint64_t
+make_uid();
+
 /** Return a random salt.
 
     This function will use the system provided random
@@ -29,6 +40,91 @@ namespace nudb {
 template<class = void>
 std::uint64_t
 make_salt();
+
+/** Create a new database.
+
+    This function creates a set of new database files with
+    the given parameters. The files must not already exist or
+    else an error is returned.
+
+    If an error occurs while the files are being created,
+    the function attempts to remove the files before
+    returning.
+
+    @par Example
+    @code
+        error_code ec;
+        create<xxhasher>(
+            "db.dat", "db.key", "db.log",
+                1, make_uid(), make_salt(), 8, 4096, 0.5f, ec);
+    @endcode
+
+    @par Template Parameters
+
+    @tparam Hasher The hash function to use. This type must
+    meet the requirements of @b Hasher. The same hash
+    function must be used every time the database is opened,
+    or else an error is returned. The provided @ref xxhasher
+    is a suitable general purpose hash function.
+
+    @tparam File The type of file to use. Use the default of
+    @ref native_file unless customizing the file behavior.
+
+    @param dat_path The path to the data file.
+
+    @param key_path The path to the key file.
+
+    @param log_path The path to the log file.
+
+    @param appnum A caller-defined value stored in the file
+    headers. When opening the database, the same value is
+    preserved and returned to the caller.
+
+    @param uid A random unsigned integer used as a unique
+    database id (uid) to make it unpredictable. The return
+    value of @ref make_uid returns a suitable value.
+
+    @param salt A random unsigned integer used to permute
+    the hash function to make it unpredictable. The return
+    value of @ref make_salt returns a suitable value.
+
+    @param key_size The number of bytes in each key.
+
+    @param blockSize The size of a key file block. Larger
+    blocks hold more keys but require more I/O cycles per
+    operation. The ideal block size the largest size that
+    may be read in a single I/O cycle, and device dependent.
+    The return value of @ref block_size returns a suitable
+    value for the volume of a given path.
+    
+    @param load_factor A number between zero and one
+    representing the average bucket occupancy (number of
+    items). A value of 0.5 is perfect. Lower numbers
+    waste space, and higher numbers produce negligible
+    savings at the cost of increased I/O cycles.
+
+    @param ec Set to the error, if any occurred.
+
+    @param args Optional arguments passed to @b File constructors.
+*/
+template<
+    class Hasher,
+    class File = native_file,
+    class... Args
+>
+void
+create(
+    path_type const& dat_path,
+    path_type const& key_path,
+    path_type const& log_path,
+    std::uint64_t appnum,
+    std::uint64_t uid,
+    std::uint64_t salt,
+    nsize_t key_size,
+    nsize_t blockSize,
+    float load_factor,
+    error_code& ec,
+    Args&&... args);
 
 /** Create a new database.
 
@@ -81,7 +177,7 @@ make_salt();
     may be read in a single I/O cycle, and device dependent.
     The return value of @ref block_size returns a suitable
     value for the volume of a given path.
-    
+
     @param load_factor A number between zero and one
     representing the average bucket occupancy (number of
     items). A value of 0.5 is perfect. Lower numbers

--- a/include/nudb/impl/create.ipp
+++ b/include/nudb/impl/create.ipp
@@ -20,9 +20,7 @@
 
 namespace nudb {
 
-namespace detail {
-
-template<class = void>
+template<class>
 std::uint64_t
 make_uid()
 {
@@ -31,8 +29,6 @@ make_uid()
     std::uniform_int_distribution <std::size_t> dist;
     return dist(gen);
 }
-
-} // detail
 
 template<class>
 std::uint64_t
@@ -55,6 +51,7 @@ create(
     path_type const& key_path,
     path_type const& log_path,
     std::uint64_t appnum,
+    std::uint64_t uid,
     std::uint64_t salt,
     nsize_t key_size,
     nsize_t blockSize,
@@ -109,7 +106,7 @@ create(
         elf = true;
         dat_file_header dh;
         dh.version = currentVersion;
-        dh.uid = make_uid();
+        dh.uid = uid;
         dh.appnum = appnum;
         dh.key_size = key_size;
 
@@ -156,6 +153,29 @@ fail:
         erase_file(key_path);
     if(elf)
         erase_file(log_path);
+}
+
+template<
+    class Hasher,
+    class File,
+    class... Args
+>
+void
+create(
+    path_type const& dat_path,
+    path_type const& key_path,
+    path_type const& log_path,
+    std::uint64_t appnum,
+    std::uint64_t salt,
+    nsize_t key_size,
+    nsize_t blockSize,
+    float load_factor,
+    error_code& ec,
+    Args&&... args)
+{
+    create<Hasher>(dat_path, key_path, log_path,
+            appnum, make_uid(), salt, key_size, blockSize,
+            load_factor, ec, args...);
 }
 
 } // nudb

--- a/include/nudb/version.hpp
+++ b/include/nudb/version.hpp
@@ -14,8 +14,8 @@
 //  NUDB_VERSION / 100 % 1000 is the minor version
 //  NUDB_VERSION / 100000 is the major version
 //
-#define NUDB_VERSION 200002
+#define NUDB_VERSION 200003
 
-#define NUDB_VERSION_STRING "2.0.2"
+#define NUDB_VERSION_STRING "2.0.3"
 
 #endif


### PR DESCRIPTION
Deterministic shards of rippled require fixed uid of database. To provide this functionality, new function create() is introduced which have additional uid parameter.