### PR TITLE
Added function context::flush()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.4
+
+* Add method context::flush() to manually flush all inserted records to disk.
+
+---
+
 2.0.3
 
 * Update docca submodule

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required (VERSION 3.11)
 set (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/scripts ${CMAKE_MODULE_PATH})
-project (NuDB VERSION 2.0.3)
+project (NuDB VERSION 2.0.4)
 
 if (POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)

--- a/include/nudb/context.hpp
+++ b/include/nudb/context.hpp
@@ -77,6 +77,18 @@ public:
     void
     run();
 
+    /** Flush function.
+
+        Manually flushes all inserted objects to the disk.
+        If using this function, @ref start should not be called.
+        If the context object has been started manually or by the default
+        constructor of @ref basic_store, a call to this function will be
+        ignored and do nothing.
+    */
+    NUDB_DECL
+    void
+    flush();
+
 private:
     using clock_type = std::chrono::steady_clock;
     using store_base = detail::store_base;

--- a/include/nudb/version.hpp
+++ b/include/nudb/version.hpp
@@ -14,8 +14,8 @@
 //  NUDB_VERSION / 100 % 1000 is the minor version
 //  NUDB_VERSION / 100000 is the major version
 //
-#define NUDB_VERSION 200003
+#define NUDB_VERSION 200004
 
-#define NUDB_VERSION_STRING "2.0.3"
+#define NUDB_VERSION_STRING "2.0.4"
 
 #endif


### PR DESCRIPTION
This function manually flushes all inserted records to the disk. Needed for rippled deterministic shards. 