### PR TITLE
Remove insert latency burstiness, fix issue #83

### DIFF
--- a/include/nudb/basic_store.hpp
+++ b/include/nudb/basic_store.hpp
@@ -78,6 +78,7 @@ private:
         detail::key_file_header kh;
 
         std::size_t rate = 0;
+        std::size_t burst = 4 * 1024 * 1024;
         time_point when = clock_type::now();
 
         state(state const&) = delete;
@@ -425,6 +426,22 @@ public:
     void
     insert(void const* key, void const* data,
         nsize_t bytes, error_code& ec);
+
+    /** Set the burst size
+
+        This function sets the amount of data that can be
+        cached before writing threads are throttled if the
+        sustained write flush rate is exceeded.
+
+        @par Thread safety
+
+        Safe to call concurrently with any function except
+        @ref close.
+
+        @param burst_size The number of bytes before throttling.
+    */
+    void
+    set_burst(std::size_t burst_size);
 
 private:
     template<class Callback>


### PR DESCRIPTION
As reported in issue #83, insertion latency sometimes shows large spikes due to two defects in NuDB's write throttling code:

1. If a burst of inserts occurs immediately after a batch write finishes, they may temporarily exceed the proven sustained write
rate. This is common and doesn't require any throttling.

2. When a small batch write completes, the execution time may be dominated by overhead, resulting in an artificially low measurement of the sustained store rate. We don't want to replace our measurement from a large batch with that one.

This change adds a default "burst size" of 4MB. For write batches below this size, we do not update our measurement of the sustained store writes. And until the size of the new write batch reaches this size, we do not throttle writes.

The burst size can be set with a "set_burst" function. Setting a burst size of zero restores the original behavior. Tuning this should not be necessary.