### PR TITLE
Fix compile warnings

### DIFF
--- a/include/nudb/detail/store_base.hpp
+++ b/include/nudb/detail/store_base.hpp
@@ -16,6 +16,8 @@ namespace detail {
 
 class store_base
 {
+    virtual ~store_base() = default;
+
 protected:
     friend class nudb::context;
 

--- a/include/nudb/impl/create.ipp
+++ b/include/nudb/impl/create.ipp
@@ -120,7 +120,7 @@ create(
         kh.block_size = blockSize;
         kh.load_factor = std::min<std::size_t>(
             static_cast<std::size_t>(
-                65536.0 * load_factor), 65535);
+                65536.0f * load_factor), 65535);
         write(df, dh, ec);
         if(ec)
             goto fail;

--- a/include/nudb/impl/rekey.ipp
+++ b/include/nudb/impl/rekey.ipp
@@ -82,7 +82,7 @@ rekey(
     kh.pepper = pepper<Hasher>(kh.salt);
     kh.block_size = blockSize;
     kh.load_factor = std::min<std::size_t>(
-        static_cast<std::size_t>(65536.0 * loadFactor), 65535);
+        static_cast<std::size_t>(65536.0f * loadFactor), 65535);
     kh.buckets = static_cast<std::size_t>(
         std::ceil(itemCount /(
             bucket_capacity(kh.block_size) * loadFactor)));


### PR DESCRIPTION
Fix such compile warnings as ```-Werror=non-virtual-dtor```, ```-Werror=double-promotion```.
Here it is an errors that I have got during the compilation using the gcc 10.2.0 compiler.
```
error: implicit conversion from ‘float’ to ‘double’ to match other operand of binary expression [-Werror=double-promotion]
  123 |                 65536.0 * load_factor), 65535);
```
```
  error: implicit conversion from ‘float’ to ‘double’ to match other operand of binary expression [-Werror=double-promotion]
   85 |         static_cast<std::size_t>(65536.0 * loadFactor), 65535);
```
```
error: ‘class nudb::detail::store_base’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
   17 | class store_base
```
```
cc1plus: all warnings being treated as errors
```