### PR TITLE
Remove coveralls test

### DIFF
--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -147,7 +147,7 @@ if [[ ${VARIANT} == coverage ]]; then
   lcov -e "lcov-all.info" "${PWD}/include/nudb/*" -o lcov.info > /dev/null
   lcov --remove "lcov.info" "${PWD}/include/nudb/_experimental/*" -o lcov.info > /dev/null
   ~/.local/bin/codecov -X gcov -f lcov.info
-  cat lcov.info | node_modules/.bin/coveralls
+  # cat lcov.info | node_modules/.bin/coveralls
   # Clean up these stragglers so BOOST_ROOT cache is clean
   find ${BOOST_ROOT}/bin.v2 -name "*.gcda" | xargs rm -f
 else


### PR DESCRIPTION
It is possible to enable the coveralls test by adding a secret in Drone settings named coveralls_repo_token.  This will be loaded in the .drone.star file 
```
 'COVERALLS_REPO_TOKEN': {'from_secret': 'coveralls_repo_token'}}
```

Or, optionally, merge the change included here which will remove coveralls.