### PR TITLE
Avoid unnecessary I/O to track files' 'last access' timestamp:

### DIFF
--- a/include/nudb/impl/posix_file.ipp
+++ b/include/nudb/impl/posix_file.ipp
@@ -240,6 +240,13 @@ flags(file_mode mode)
     #endif
         break;
     }
+
+#ifdef O_NOATIME
+    // Avoid updating the file's "last access time" with every
+    // read, if that's an option.
+    result.first |= O_NOATIME;
+#endif
+
     return result;
 }
 


### PR DESCRIPTION
Unless the underlying filesystem is mounted with `noatime` then the system will keep track of and update a file's 'last access' time stamp with every `read` operation.

Even if the filesystem optimizes this, it makes little sense to track this information for NuDB files that can be accessed tens of thousands of times per second.

If the `O_NOATIME` option is defined, we set it when attempting to open or create files.