### PR TITLE
[TRIVIAL] Add missing includes

### DIFF
--- a/include/nudb/detail/stream.hpp
+++ b/include/nudb/detail/stream.hpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <stdexcept>
 
 namespace nudb {
 namespace detail {

--- a/include/nudb/impl/context.ipp
+++ b/include/nudb/impl/context.ipp
@@ -9,6 +9,7 @@
 #define NUDB_IMPL_CONTEXT_IPP
 
 #include <nudb/detail/store_base.hpp>
+#include <stdexcept>
 
 namespace nudb {
 


### PR DESCRIPTION
`std::logic_error` is defined in `<stdexcept>`. These files changed in this PR reference it without including that header. In most environments, the definition is included through other headers, but not all. Specifically, I ran into a build error with [rippled](https://github.com/XRPLF/rippled) Windows non-unity builds after some headers were reordered.

See also: https://github.com/XRPLF/rippled/pull/5061